### PR TITLE
PRO-442: Bump alpine to 3.16.0

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15.3
+FROM alpine:3.16.0
 
 ARG AWS_CLI_VERSION=1.22.81
 

--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -1,5 +1,5 @@
 # Release Container
-FROM alpine:3.15.3 as release
+FROM alpine:3.16.0 as release
 
 ENV MIX_ENV=prod
 ENV REPLACE_OS_VARS true


### PR DESCRIPTION
Required for upstream hexpm/elixir container support